### PR TITLE
Return parser IDs

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -17,7 +17,7 @@ fn tree_parsing(bencher: &mut Bencher) {
     let mut peel = peel_example();
     let input = b"1234";
     bencher.iter(|| {
-        peel.traverse(input, vec![]);
+        peel.traverse(input, vec![], vec![]);
     });
     bencher.bytes = input.len() as u64;
 }

--- a/examples/peel.rs
+++ b/examples/peel.rs
@@ -13,9 +13,9 @@ fn main() {
     peel.set_log_level(LogLevel::Info);
 
     let last_node = peel.graph.node_indices().last().unwrap();
-    peel.link_new_parser(last_node, MyParser);
+    peel.link_new_parser(last_node, MyParser, ParserId::Other(1));
 
-    let result = peel.traverse(b"12345", vec![]).result;
+    let result = peel.traverse(b"12345", vec![], vec![]).result;
     assert_eq!(result.len(), 5);
     assert_eq!(result[4].downcast_ref::<MyParserResult>(),
                Some(&MyParserResult));

--- a/graph.dot
+++ b/graph.dot
@@ -1,8 +1,8 @@
 digraph {
-    0 [label="\"Parser1\""]
-    1 [label="\"Parser2\""]
-    2 [label="\"Parser3\""]
-    3 [label="\"Parser4\""]
+    0 [label="\"(Parser1, Parser1)\""]
+    1 [label="\"(Parser2, Parser2)\""]
+    2 [label="\"(Parser3, Parser3)\""]
+    3 [label="\"(Parser4, Parser4)\""]
     0 -> 1
     0 -> 2
     1 -> 2

--- a/src/example/mod.rs
+++ b/src/example/mod.rs
@@ -11,7 +11,7 @@ pub mod prelude {
     pub use std::fmt;
     pub use Peel;
     pub use parser::{Parsable, ParserResult, ParserResultVec};
-    pub use super::peel_example;
+    pub use super::{peel_example, ParserId};
     pub use nom::IResult;
 
     pub use example::parser1::*;
@@ -20,16 +20,31 @@ pub mod prelude {
     pub use example::parser4::*;
 }
 
+/// An ID of a parser for the `peel_example` parsers.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ParserId {
+    /// `parser1::Parser1`
+    Parser1,
+    /// `parser2::Parser2`
+    Parser2,
+    /// `parser3::Parser3`
+    Parser3,
+    /// `parser4::Parser4`
+    Parser4,
+    /// Something else
+    Other(usize),
+}
+
 /// Return a `Peel` instance for the example parsers
-pub fn peel_example() -> Peel<()> {
+pub fn peel_example() -> Peel<(), ParserId> {
     // Create a tree
     let mut p = Peel::new();
 
     // Create some parsers
-    let parser_1 = p.new_parser(Parser1);
-    let parser_2 = p.new_parser(Parser2);
-    let parser_3 = p.new_parser(Parser3);
-    let parser_4 = p.new_parser(Parser4);
+    let parser_1 = p.new_parser(Parser1, ParserId::Parser1);
+    let parser_2 = p.new_parser(Parser2, ParserId::Parser2);
+    let parser_3 = p.new_parser(Parser3, ParserId::Parser3);
+    let parser_4 = p.new_parser(Parser4, ParserId::Parser4);
 
     // Link the parsers together
     p.link_nodes(&[(parser_1, parser_2),


### PR DESCRIPTION
In addition to the results, return IDs of the parsers, so the user can
recognize them.

This is the first experiment discussed in #2. I'd like to try the ideas out first and see if they are possible. Afterwards I'd like to do some API and code clean-ups to make it more comfortable to use.

I'll be glad for feedback on the code.

Anyway, how to proceed with the experiments? Would it make sense to create an „experiments“ branch, merge each of the experiments there and once/if something reasonable comes of it, merge the whole thing to master? On one hand, I don't want to merge the changes to master until the bigger picture is done, but I'd still like to chunk the changes into smaller pull requests if possible.